### PR TITLE
Fix Rich markup errors in decoder output

### DIFF
--- a/unified_decoder.py
+++ b/unified_decoder.py
@@ -194,7 +194,11 @@ class Stanag4285Decoder:
         for t in preambles:
             seg = self.id_extractor.extract(t, bits)
             results.append(seg)
-            console.print(f"[green]Burst at {t:.3f} sec → {self._bits_to_ascii(seg)}[/green]")
+            console.print(
+                f"Burst at {t:.3f} sec → {self._bits_to_ascii(seg)}",
+                style="green",
+                markup=False,
+            )
 
         if plot and plt is not None:
             time_env = np.arange(len(env)) / rate_env


### PR DESCRIPTION
## Summary
- disable markup when printing decoded burst text

## Testing
- `python -m py_compile unified_decoder.py`


------
https://chatgpt.com/codex/tasks/task_e_6849c775690c832282d2c52f4d6f603e