### PR TITLE
Add JSON output and plotting options

### DIFF
--- a/unified_decoder.py
+++ b/unified_decoder.py
@@ -1,6 +1,8 @@
 import argparse
 from dataclasses import dataclass
 from typing import Iterable, List
+import json
+import concurrent.futures
 #
 import numpy as np
 import scipy.io.wavfile as wav
@@ -125,17 +127,32 @@ class Descrambler:
 class PreambleDetector:
     """Detect preambles by correlating with a known bit pattern."""
 
-    def __init__(self, pattern: np.ndarray, bit_rate: int, threshold: float = 0.8) -> None:
+    def __init__(
+        self,
+        pattern: np.ndarray,
+        bit_rate: int,
+        threshold: float = 0.85,
+        holdoff_sec: float = HOLD_OFF_SEC,
+    ) -> None:
         self.pattern = np.array(pattern, dtype=np.uint8)
         self.bit_rate = bit_rate
         self.threshold = threshold
+        self.holdoff_bits = int(holdoff_sec * bit_rate)
 
     def detect(self, bit_stream: np.ndarray) -> List[float]:
         pattern_pm = 2 * self.pattern - 1
         stream_pm = 2 * bit_stream - 1
         corr = np.correlate(stream_pm, pattern_pm, mode="valid") / len(self.pattern)
         idx = np.where(corr >= self.threshold)[0]
-        return (idx / self.bit_rate).tolist()
+
+        filtered: List[int] = []
+        last = -self.holdoff_bits
+        for i in idx:
+            if i - last >= self.holdoff_bits:
+                filtered.append(i)
+                last = i
+
+        return [i / self.bit_rate for i in filtered]
 
 
 class StationIdExtractor:
@@ -159,7 +176,9 @@ class Stanag4285Decoder:
         self.burst_finder = BurstFinder()
         self.demodulator = QpskDemodulator()
         self.descrambler = Descrambler()
-        self.preamble_detector = PreambleDetector(preamble, BIT_RATE)
+        self.preamble_detector = PreambleDetector(
+            preamble, BIT_RATE, threshold=0.85, holdoff_sec=HOLD_OFF_SEC
+        )
         self.id_extractor = StationIdExtractor()
 
     def _bits_to_ascii(self, bits: np.ndarray) -> str:
@@ -172,7 +191,12 @@ class Stanag4285Decoder:
             out.append(byte)
         return "".join(chr(b) if 32 <= b <= 126 else "." for b in out)
 
-    def decode(self, plot: bool = False) -> List[np.ndarray]:
+    def decode(
+        self,
+        plot: bool = False,
+        plot_file: str = "detected_bursts.png",
+        json_outfile: str = "decoded_results.json",
+    ) -> List[np.ndarray]:
         self.signal.load()
         env, rate_env = self.signal.envelope()
         burst_times = self.burst_finder.find(env, rate_env)
@@ -190,15 +214,22 @@ class Stanag4285Decoder:
             return []
 
         console.print(f"[bold cyan]Detected {len(preambles)} burst(s).[/bold cyan]")
-        results: List[np.ndarray] = []
-        for t in preambles:
+
+        def process_burst(t: float) -> dict:
             seg = self.id_extractor.extract(t, bits)
-            results.append(seg)
-            console.print(
-                f"Burst at {t:.3f} sec → {self._bits_to_ascii(seg)}",
-                style="green",
-                markup=False,
-            )
+            return {
+                "time": t,
+                "ascii": self._bits_to_ascii(seg),
+            }
+
+        with concurrent.futures.ThreadPoolExecutor() as ex:
+            burst_info = list(ex.map(process_burst, preambles))
+
+        results: List[np.ndarray] = [self.id_extractor.extract(t, bits) for t in preambles]
+
+        with open(json_outfile, "w") as f:
+            json.dump(burst_info, f, indent=2)
+        console.print(f"[green]Results written to {json_outfile}[/green]")
 
         if plot and plt is not None:
             time_env = np.arange(len(env)) / rate_env
@@ -211,7 +242,8 @@ class Stanag4285Decoder:
             plt.ylabel("Amplitude Variance")
             plt.title("Detected Bursts")
             plt.tight_layout()
-            plt.show()
+            plt.savefig(plot_file)
+            plt.close()
 
         return results
 
@@ -219,10 +251,24 @@ class Stanag4285Decoder:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Decode STANAG 4285 station ID from WAV")
     parser.add_argument("wavfile", help="Input WAV file")
-    parser.add_argument("--plot", action="store_true", help="Show diagnostic plot")
+    parser.add_argument("--plot", action="store_true", help="Save diagnostic plot")
+    parser.add_argument(
+        "--plot-file",
+        default="detected_bursts.png",
+        help="Filename for plot image",
+    )
+    parser.add_argument(
+        "--outfile",
+        default="decoded_results.json",
+        help="JSON file for decoded ASCII",
+    )
     args = parser.parse_args()
 
-    Stanag4285Decoder(args.wavfile).decode(plot=args.plot)
+    Stanag4285Decoder(args.wavfile).decode(
+        plot=args.plot,
+        plot_file=args.plot_file,
+        json_outfile=args.outfile,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow saving diagnostic plots to a file
- save decoded ASCII bursts to a JSON file
- parallelize per-burst processing
- add hold-off to preamble detection and raise threshold to cut down false positives

## Testing
- `python -m py_compile unified_decoder.py`
- `python unified_decoder.py --help`


------
https://chatgpt.com/codex/tasks/task_e_6849d1856018832284d04321e3d405df